### PR TITLE
fix(tests): fix failing path mapping tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
       "<rootDir>/libs/"
     ],
     "moduleNameMapper": {
+      "@lib/testlib": "<rootDir>/libs/testlib/src",
       "@lib/testlib/(.*)": "<rootDir>/libs/testlib/src/$1"
     }
   }

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -5,5 +5,9 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "@lib/testlib": "<rootDir>/../libs/testlib/src",
+    "@lib/testlib/(.*)": "<rootDir>/../libs/testlib/src/$1"
   }
 }


### PR DESCRIPTION
In your original path mapping, you declared `@lib/testlib/*` which will handle anything that is prefixed with `@lib/testlib` and have a forward slash and then a name. In your import statements however, you were using `@lib/testlib` which does not match the above regex and therefore cannot be resolved. In your `tsconfig` you had already taken care of mapping `@lib/testlib` so all that had to happen was to mirror that config in your jest configurations. You can now run the tests (both `test` and `test:e2e`) and see successful, passing tests. 😄 